### PR TITLE
Feature 34 change proposals approvals

### DIFF
--- a/src/main/kotlin/fi/metatavu/lipsanen/exceptions/TaskOutsideMilestoneException.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/exceptions/TaskOutsideMilestoneException.kt
@@ -1,0 +1,14 @@
+package fi.metatavu.lipsanen.exceptions
+
+import java.time.LocalDate
+import java.util.*
+
+/**
+ * Exception for task outside milestone boundaries
+ *
+ * @param taskId task id
+ * @param startDate new start date
+ * @param endDate new end date
+ */
+class TaskOutsideMilestoneException(taskId: UUID, startDate: LocalDate, endDate: LocalDate) :
+    Exception("Task $taskId with new dates $startDate - $endDate goes out of the milestone boundaries")

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/MilestoneController.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/MilestoneController.kt
@@ -1,6 +1,7 @@
 package fi.metatavu.lipsanen.projects.milestones
 
 import fi.metatavu.lipsanen.api.model.Milestone
+import fi.metatavu.lipsanen.projects.ProjectController
 import fi.metatavu.lipsanen.projects.ProjectEntity
 import fi.metatavu.lipsanen.projects.milestones.tasks.TaskController
 import fi.metatavu.lipsanen.projects.milestones.tasks.TaskEntity
@@ -17,6 +18,9 @@ import java.util.*
  */
 @ApplicationScoped
 class MilestoneController {
+
+    @Inject
+    lateinit var projectController: ProjectController
 
     @Inject
     lateinit var milestoneRepository: MilestoneRepository
@@ -191,9 +195,7 @@ class MilestoneController {
                 return "Milestone cannot be shortened to earlier than task ${it.name} start date"
             }
         }
-
         return null
     }
-
 
 }

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/MilestonesApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/MilestonesApiImpl.kt
@@ -63,7 +63,7 @@ class MilestonesApiImpl : ProjectMilestonesApi, AbstractApi() {
             if (!projectController.hasAccessToProject(project, userId)) {
                 return@async createForbidden(NO_PROJECT_RIGHTS)
             }
-            if (!projectController.isInPlanningStage(project)) {
+            if (!isAdmin() && !projectController.isInPlanningStage(project)) {
                 return@async createBadRequest(WRONG_PROJECT_STAGE)
             }
 
@@ -112,10 +112,9 @@ class MilestonesApiImpl : ProjectMilestonesApi, AbstractApi() {
                 return@async createForbidden(NO_PROJECT_RIGHTS)
             }
 
-            if (!projectController.isInPlanningStage(project)) {
+            if (!isAdmin() && !projectController.isInPlanningStage(project)) {
                 return@async createBadRequest(WRONG_PROJECT_STAGE)
             }
-
 
             val foundMilestone = milestoneController.find(project, milestoneId) ?: return@async createNotFound(
                 createNotFoundMessage(MILESTONE, milestoneId)
@@ -156,7 +155,7 @@ class MilestonesApiImpl : ProjectMilestonesApi, AbstractApi() {
                 return@async createForbidden(NO_PROJECT_RIGHTS)
             }
 
-            if (!projectController.isInPlanningStage(project)) {
+            if (!isAdmin() && !projectController.isInPlanningStage(project)) {
                 return@async createBadRequest(WRONG_PROJECT_STAGE)
             }
 

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TaskController.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TaskController.kt
@@ -1,6 +1,7 @@
 package fi.metatavu.lipsanen.projects.milestones.tasks
 
 import fi.metatavu.lipsanen.api.model.*
+import fi.metatavu.lipsanen.exceptions.TaskOutsideMilestoneException
 import fi.metatavu.lipsanen.projects.ProjectEntity
 import fi.metatavu.lipsanen.projects.milestones.MilestoneEntity
 import fi.metatavu.lipsanen.projects.milestones.tasks.connections.TaskConnectionController
@@ -365,14 +366,4 @@ class TaskController {
             }
         }
     }
-
-    /**
-     * Exception for task outside milestone boundaries
-     *
-     * @param taskId task id
-     * @param startDate new start date
-     * @param endDate new end date
-     */
-    class TaskOutsideMilestoneException(taskId: UUID, startDate: LocalDate, endDate: LocalDate) :
-        Exception("Task $taskId with new dates $startDate - $endDate goes out of the milestone boundaries")
 }

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TasksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TasksApiImpl.kt
@@ -117,7 +117,7 @@ class TasksApiImpl : TasksApi, AbstractApi() {
                 createNotFoundMessage(TASK, taskId)
             )
 
-            if (!projectController.isInPlanningStage(projectMilestone.second)) {
+            if (!isAdmin() && !projectController.isInPlanningStage(projectMilestone.second)) {
                 return@async createBadRequest(INVALID_PROJECT_STATE)
             }
 

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TasksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TasksApiImpl.kt
@@ -4,10 +4,7 @@ import fi.metatavu.lipsanen.api.model.Task
 import fi.metatavu.lipsanen.api.model.TaskConnectionType
 import fi.metatavu.lipsanen.api.model.TaskStatus
 import fi.metatavu.lipsanen.api.spec.TasksApi
-import fi.metatavu.lipsanen.projects.ProjectController
-import fi.metatavu.lipsanen.projects.ProjectEntity
-import fi.metatavu.lipsanen.projects.milestones.MilestoneController
-import fi.metatavu.lipsanen.projects.milestones.MilestoneEntity
+import fi.metatavu.lipsanen.projects.milestones.tasks.TaskController.TaskOutsideMilestoneException
 import fi.metatavu.lipsanen.projects.milestones.tasks.connections.TaskConnectionRepository
 import fi.metatavu.lipsanen.rest.AbstractApi
 import fi.metatavu.lipsanen.rest.UserRole
@@ -138,7 +135,7 @@ class TasksApiImpl : TasksApi, AbstractApi() {
                     userId = userId
                 )
                 return@async createOk(taskTranslator.translate(updatedTask))
-            } catch (e: IllegalArgumentException) {
+            } catch (e: TaskOutsideMilestoneException) {
                 return@async createBadRequest(e.message!!)
             }
 

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TasksApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/TasksApiImpl.kt
@@ -130,14 +130,18 @@ class TasksApiImpl : TasksApi, AbstractApi() {
                 return@async createConflict(updateError)
             }
 
-            val updatedTask = taskController.update(
-                existingTask = foundTask,
-                newTask = task,
-                milestone = projectMilestone.first,
-                userId = userId
-            )
+            try {
+                val updatedTask = taskController.update(
+                    existingTask = foundTask,
+                    newTask = task,
+                    milestone = projectMilestone.first,
+                    userId = userId
+                )
+                return@async createOk(taskTranslator.translate(updatedTask))
+            } catch (e: IllegalArgumentException) {
+                return@async createBadRequest(e.message!!)
+            }
 
-            return@async createOk(taskTranslator.translate(updatedTask))
         }.asUni()
 
     @WithTransaction

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/connections/TaskConnectionController.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/connections/TaskConnectionController.kt
@@ -51,13 +51,24 @@ class TaskConnectionController {
         }
     }
 
+    /**
+     * Lists task connections
+     *
+     * @param task task
+     * @return list of task connections
+     */
     suspend fun list(
         task: TaskEntity,
+        connectionRole: TaskConnectionRole? = null
     ): List<TaskConnectionEntity> {
-
-
-        return        taskConnectionRepository.listByTasks(arrayListOf(task))
-
+        return if (connectionRole == null) {
+            taskConnectionRepository.listByTasks(arrayListOf(task))
+        } else {
+            when (connectionRole) {
+                TaskConnectionRole.SOURCE -> taskConnectionRepository.listBySourceTask(task)
+                TaskConnectionRole.TARGET -> taskConnectionRepository.listByTargetTask(task)
+            }
+        }
     }
 
 

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/connections/TaskConnectionController.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/connections/TaskConnectionController.kt
@@ -2,6 +2,7 @@ package fi.metatavu.lipsanen.projects.milestones.tasks.connections
 
 import fi.metatavu.lipsanen.api.model.TaskConnection
 import fi.metatavu.lipsanen.api.model.TaskConnectionRole
+import fi.metatavu.lipsanen.api.model.TaskConnectionType
 import fi.metatavu.lipsanen.projects.ProjectEntity
 import fi.metatavu.lipsanen.projects.milestones.MilestoneController
 import fi.metatavu.lipsanen.projects.milestones.tasks.TaskController
@@ -141,6 +142,35 @@ class TaskConnectionController {
     suspend fun delete(foundConnection: TaskConnectionEntity) {
         taskConnectionRepository.deleteSuspending(foundConnection)
     }
+
+
+    /**
+     * Verifies task connection logic
+     *
+     * @param sourceTask source task
+     * @param targetTask target task
+     * @param type connection type
+     * @return error message if connection is invalid, null otherwise
+     */
+    fun verifyTaskConnection(sourceTask: TaskEntity, targetTask: TaskEntity, type: TaskConnectionType): String? {
+        if (sourceTask == targetTask)
+            return ("Source and target tasks cannot be the same")
+
+        return when (type) {
+            TaskConnectionType.START_TO_START -> if (sourceTask.startDate > targetTask.startDate) {
+                "Source task start date cannot be after target task start date"
+            } else null
+
+            TaskConnectionType.FINISH_TO_FINISH -> if (sourceTask.endDate > targetTask.endDate) {
+                "Source task end date cannot be after target task end date"
+            } else null
+
+            TaskConnectionType.FINISH_TO_START -> if (sourceTask.endDate > targetTask.startDate) {
+                "Source task end date cannot be after target task start date"
+            } else null
+        }
+    }
+
 
     /**
      * Gets the task filter based on project of provided task

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/connections/TaskConnectionsApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/connections/TaskConnectionsApiImpl.kt
@@ -52,7 +52,7 @@ class TaskConnectionsApiImpl : TaskConnectionsApi, AbstractApi() {
         connectionRole: TaskConnectionRole?
     ): Uni<Response> = CoroutineScope(vertx.dispatcher()).async {
         val userId = loggedUserId ?: return@async createUnauthorized(UNAUTHORIZED)
-        val (project, errorResponse) = getProjectOrError(projectId, userId)//todo move this
+        val (project, errorResponse) = getProjectOrError(projectId, userId)
         if (errorResponse != null) return@async errorResponse
 
         val task = if (taskId != null) {
@@ -81,7 +81,7 @@ class TaskConnectionsApiImpl : TaskConnectionsApi, AbstractApi() {
             return@async createBadRequest(INVALID_PROJECT_STATE)
         }
 
-        val sourceTask = taskController.find(project!!, taskConnection.sourceTaskId) ?: return@async createNotFound(
+        val sourceTask = taskController.find(project, taskConnection.sourceTaskId) ?: return@async createNotFound(
             createNotFoundMessage(TASK, taskConnection.sourceTaskId)
         )
         val targetTask = taskController.find(project, taskConnection.targetTaskId) ?: return@async createNotFound(
@@ -95,8 +95,6 @@ class TaskConnectionsApiImpl : TaskConnectionsApi, AbstractApi() {
         val createdTaskConnection = taskConnectionController.create(sourceTask, targetTask, taskConnection, userId)
         createOk(taskConnectionTranslator.translate(createdTaskConnection))
     }.asUni()
-
-
 
     @RolesAllowed(UserRole.ADMIN.NAME, UserRole.USER.NAME)
     override fun findTaskConnection(

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalRepository.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalRepository.kt
@@ -5,13 +5,13 @@ import fi.metatavu.lipsanen.persistence.AbstractRepository
 import fi.metatavu.lipsanen.projects.milestones.tasks.TaskEntity
 import jakarta.enterprise.context.ApplicationScoped
 import java.time.LocalDate
-import java.util.UUID
+import java.util.*
 
 /**
  * Repository for proposals
  */
 @ApplicationScoped
-class ChangeProposalRepository: AbstractRepository<ChangeProposalEntity, UUID>() {
+class ChangeProposalRepository : AbstractRepository<ChangeProposalEntity, UUID>() {
 
     /**
      * Creates a new proposal

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalTranslator.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalTranslator.kt
@@ -10,7 +10,7 @@ import jakarta.inject.Inject
  * Translator for proposals
  */
 @ApplicationScoped
-class ChangeProposalTrnaslator : AbstractTranslator<ChangeProposalEntity, ChangeProposal>() {
+class ChangeProposalTranslator : AbstractTranslator<ChangeProposalEntity, ChangeProposal>() {
 
     @Inject
     lateinit var metadataTranslator: MetadataTranslator

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalsApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalsApiImpl.kt
@@ -2,6 +2,7 @@ package fi.metatavu.lipsanen.projects.milestones.tasks.proposals
 
 import fi.metatavu.lipsanen.api.model.ChangeProposal
 import fi.metatavu.lipsanen.api.spec.ChangeProposalsApi
+import fi.metatavu.lipsanen.exceptions.TaskOutsideMilestoneException
 import fi.metatavu.lipsanen.projects.milestones.tasks.TaskController
 import fi.metatavu.lipsanen.rest.AbstractApi
 import fi.metatavu.lipsanen.rest.UserRole

--- a/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalsApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/projects/milestones/tasks/proposals/ChangeProposalsApiImpl.kt
@@ -3,6 +3,7 @@ package fi.metatavu.lipsanen.projects.milestones.tasks.proposals
 import fi.metatavu.lipsanen.api.model.ChangeProposal
 import fi.metatavu.lipsanen.api.spec.ChangeProposalsApi
 import fi.metatavu.lipsanen.projects.milestones.tasks.TaskController
+import fi.metatavu.lipsanen.projects.milestones.tasks.TaskController.TaskOutsideMilestoneException
 import fi.metatavu.lipsanen.rest.AbstractApi
 import fi.metatavu.lipsanen.rest.UserRole
 import io.quarkus.hibernate.reactive.panache.common.WithSession
@@ -32,7 +33,7 @@ class ChangeProposalsApiImpl : ChangeProposalsApi, AbstractApi() {
     lateinit var proposalController: ChangeProposalController
 
     @Inject
-    lateinit var changeProposalTrnaslator: ChangeProposalTrnaslator
+    lateinit var changeProposalTrnaslator: ChangeProposalTranslator
 
     @Inject
     lateinit var taskController: TaskController
@@ -124,7 +125,6 @@ class ChangeProposalsApiImpl : ChangeProposalsApi, AbstractApi() {
             createNotFoundMessage(CHANGE_PROPOSAL, changeProposalId)
         )
         if (changeProposal.taskId != foundProposal.task.id) {
-            println("Proposal cannot be reassigned to other task")
             return@async createBadRequest("Proposal cannot be reassigned to other task")
         }
 
@@ -140,8 +140,7 @@ class ChangeProposalsApiImpl : ChangeProposalsApi, AbstractApi() {
             val updatedProposal = proposalController.update(foundProposal, changeProposal, userId)
             createOk(changeProposalTrnaslator.translate(updatedProposal))
 
-        } catch (e: IllegalArgumentException) {
-            println("Invalid proposal? ${e.message}")
+        } catch (e: TaskOutsideMilestoneException) {
             return@async createBadRequest(e.message!!)
         }
 

--- a/src/main/kotlin/fi/metatavu/lipsanen/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/rest/AbstractApi.kt
@@ -24,6 +24,12 @@ abstract class AbstractApi {
     @Inject
     lateinit var identity: SecurityIdentity
 
+    @Inject
+    lateinit var projectController: ProjectController
+
+    @Inject
+    lateinit var milestoneController: MilestoneController
+
     /**
      * Checks if user is admin
      *
@@ -220,12 +226,6 @@ abstract class AbstractApi {
     fun createNotFoundMessage(entity: String, id: UUID): String {
         return "$entity with id $id not found"
     }
-
-    @Inject
-    lateinit var projectController: ProjectController
-
-    @Inject
-    lateinit var milestoneController: MilestoneController
 
     /**
      * Helper method for getting project or milestone or an error response

--- a/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/ChangeProposalTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/ChangeProposalTestBuilderResource.kt
@@ -60,9 +60,9 @@ class ChangeProposalTestBuilderResource(
         return created
     }
 
-    fun create(projectId: UUID, milestoneId: UUID, taskId: UUID, changeProposal: ChangeProposal): ChangeProposal? {
+    fun create(projectId: UUID, milestoneId: UUID, changeProposal: ChangeProposal): ChangeProposal? {
         val created = addClosable(api.createChangeProposal(projectId, milestoneId, changeProposal))
-        proposalToTaskId[created.id!!] = taskId
+        proposalToTaskId[created.id!!] = changeProposal.taskId
         proposalToMilestoneId[created.id!!] = milestoneId
         proposalToProjectId[created.id!!] = projectId
         return created

--- a/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/MilestoneTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/MilestoneTestBuilderResource.kt
@@ -41,12 +41,14 @@ class MilestoneTestBuilderResource(
         return created
     }
 
-    fun create(projectId: UUID): Milestone {
+    fun create(projectId: UUID,
+               startDate: String? = null,
+               endDate: String? = null): Milestone {
         return create(
             projectId, Milestone(
                 name = "Milestone",
-                startDate = "2022-01-01",
-                endDate = "2022-01-31"
+                startDate = startDate ?: "2022-01-01",
+                endDate = endDate ?: "2022-01-31"
             )
         )
     }

--- a/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/TaskTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/TaskTestBuilderResource.kt
@@ -61,6 +61,26 @@ class TaskTestBuilderResource(
 
     fun create(
         projectId: UUID,
+        milestoneId: UUID,
+        startDate: String,
+        endDate: String,
+        name: String? = null
+    ): Task {
+        return create(
+            projectId = projectId,
+            milestoneId = milestoneId,
+            task = Task(
+                name = name ?: "Task",
+                startDate = startDate,
+                status = TaskStatus.NOT_STARTED,
+                milestoneId = milestoneId,
+                endDate = endDate
+            )
+        )
+    }
+
+    fun create(
+        projectId: UUID,
         milestoneId: UUID
     ): Task {
         return create(


### PR DESCRIPTION
https://github.com/Metatavu/lipsanen-project-management-api/issues/34
https://github.com/Metatavu/lipsanen-project-management-api/issues/31

Features include (task connection logic details, proposal acceptance, small access rights checks):

1. When tasks are updated, their movement causes cascade movement of all the tasks they are connected to (backwards and forwards based on the type of movement). So connected tasks are moved backward-forward when needing while **preserving their original length**
2. If the change above causes the affected tasks to be out of the milestone boundary, status 400
3. If the change of the ACTUAL UPDATED TASK does that, milestone boundaries are updated instead
4. Admins can edit tasks and milestones no matter the project stage
5. Proposal updates follow the same logic as in p.1-3, e.g. when proposal is approved, it updated the task using the above logic. Only admins can approve or reject those, creators of the proposals can edit their own proposals and delete them.
6. When proposal is approved, it causes the cascade update as discovered above, as the result all the proposals affecting the updated task and all affected tasks are **auto-rejected**
8. Proposal status cannot be reset back to PENDING after it's been rejected or approved
9. Task connections are verified to be valid when the connection is being created/updated, so we cannot create broken links accidentally
10. Proposals are listed from old to new