### PR TITLE
user management access rights changes

### DIFF
--- a/src/main/kotlin/fi/metatavu/lipsanen/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/rest/AbstractApi.kt
@@ -46,6 +46,15 @@ abstract class AbstractApi {
     }
 
     /**
+     * Checks if user is user management admin
+     *
+     * @return if user is user management admin
+     */
+    protected fun isUserManagementAdmin(): Boolean {
+        return identity.hasRole(UserRole.USER_MANAGEMENT_ADMIN.NAME)
+    }
+
+    /**
      * Checks if user is project owner
      *
      * @return if user is project owner

--- a/src/main/kotlin/fi/metatavu/lipsanen/users/UserController.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/users/UserController.kt
@@ -292,7 +292,7 @@ class UserController {
     }
 
     /**
-     * Updates a user (but not its email)
+     * Updates a user completely (but not its email)
      *
      * @param existingUser existing user
      * @param updateData user

--- a/src/main/kotlin/fi/metatavu/lipsanen/users/UserController.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/users/UserController.kt
@@ -93,7 +93,7 @@ class UserController {
      */
     suspend fun listUsers(
         company: CompanyEntity?,
-        projectFilter: ProjectEntity?,
+        projectFilter: List<ProjectEntity>?,
         jobPosition: JobPositionEntity?,
         keycloakId: UUID?,
         first: Int?,
@@ -198,7 +198,7 @@ class UserController {
             if (environment.orElse(null) != "test") {
                 keycloakAdminClient.getUserApi().realmUsersIdExecuteActionsEmailPut(
                     realm = keycloakAdminClient.getRealm(),
-                    id = keycloakUser.id!!,
+                    id = keycloakUser.id,
                     requestBody = arrayOf("UPDATE_PASSWORD"),
                     lifespan = null
                 )
@@ -340,11 +340,13 @@ class UserController {
      * @param roles roles to assign
      */
     suspend fun assignRoles(userRepresentation: UserRepresentation, roles: List<UserRole>?) {
-        if (roles == null) {
-            //nothing is being updated if roles are null
-            return
+        var assignableRoles = if (roles.isNullOrEmpty()) {
+            listOf(UserRole.USER)
+        } else {
+            roles
         }
-        val userRoles = roles.map {
+
+        val userRoles = assignableRoles.map {
             keycloakAdminClient.getRoleContainerApi().realmRolesRoleNameGet(
                 roleName = translateRole(it),
                 realm = keycloakAdminClient.getRealm()

--- a/src/main/kotlin/fi/metatavu/lipsanen/users/UserRepository.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/users/UserRepository.kt
@@ -62,7 +62,7 @@ class UserRepository: AbstractRepository<UserEntity, UUID>(){
         companyEntity: CompanyEntity? = null,
         keycloakId: UUID?,
         jobPosition: JobPositionEntity? = null,
-        project: ProjectEntity? = null,
+        project: List<ProjectEntity>? = null,
         firstResult: Int? = null,
         maxResults: Int? = null
     ): Pair<List<UserEntity>, Long> {
@@ -71,8 +71,8 @@ class UserRepository: AbstractRepository<UserEntity, UUID>(){
 
         if (project != null) {
             sb.append(" JOIN UserToProjectEntity utp ON u.id = utp.user.id")
-            sb.append(" WHERE utp.project = :project ")
-            parameters.and("project", project)
+            sb.append(" WHERE utp.project in :projects ")
+            parameters.and("projects", project)
         }
 
         if (companyEntity != null) {

--- a/src/main/kotlin/fi/metatavu/lipsanen/users/UsersApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/users/UsersApiImpl.kt
@@ -102,7 +102,7 @@ class UsersApiImpl: UsersApi, AbstractApi() {
         if (!isUserManagementAdmin() && !isAdmin() && !isProjectOwner()) {
             val userProjects = userController.listUserProjects(foundUser).map { it.project.id }
             val isInSameProject = userController.listUserProjects(foundUser).map { it.project.id }.intersect(userProjects.toSet()).isNotEmpty()
-            if (userId != logggedInUserId && !isInSameProject) {
+            if (foundUser.keycloakId != logggedInUserId && !isInSameProject) {
                 return@withCoroutineScope createNotFound("Unauthorized")
             }
         }

--- a/src/main/kotlin/fi/metatavu/lipsanen/users/UsersApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/users/UsersApiImpl.kt
@@ -179,15 +179,15 @@ class UsersApiImpl: UsersApi, AbstractApi() {
     /**
      * Checks if project owner can assign user to projects.
      * It can assign users to the projects that he/she is project owner of.
-     * He cannot un-assing user from the projects that he/she is not project owner of.
+     * He cannot un-assign user from the projects that he/she is not project owner of.
      *
      * @param updatingUser user who is updating the user
-     * @param updatableUser user who is being updated
+     * @param updatedUser user who is being updated
      * @param newUserProjectIds new projects that user is being assigned to
      * @return true if project owner can assign user to projects, false otherwise
      */
-    private suspend fun canAssignToProjects(updatingUser: UserEntity, updatableUser: UserEntity, newUserProjectIds: List<UUID>): Boolean {
-        val currentUserProjectIds = userController.listUserProjects(updatableUser).map { it.project.id }
+    private suspend fun canAssignToProjects(updatingUser: UserEntity, updatedUser: UserEntity, newUserProjectIds: List<UUID>): Boolean {
+        val currentUserProjectIds = userController.listUserProjects(updatedUser).map { it.project.id }
         val projectOwnerProjectIds = userController.listUserProjects(updatingUser).map { it.project.id }
 
         val projectsToAddIds = newUserProjectIds.filter { !currentUserProjectIds.contains(it) }

--- a/src/main/kotlin/fi/metatavu/lipsanen/users/UsersApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/lipsanen/users/UsersApiImpl.kt
@@ -100,7 +100,8 @@ class UsersApiImpl: UsersApi, AbstractApi() {
         val foundUser = userController.findUser(userId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(USER, userId))
 
         if (!isUserManagementAdmin() && !isAdmin() && !isProjectOwner()) {
-            val userProjects = userController.listUserProjects(foundUser).map { it.project.id }
+            val currentUser = userController.findUserByKeycloakId(logggedInUserId) ?: return@withCoroutineScope createInternalServerError("Failed to find user")
+            val userProjects = userController.listUserProjects(currentUser).map { it.project.id }
             val isInSameProject = userController.listUserProjects(foundUser).map { it.project.id }.intersect(userProjects.toSet()).isNotEmpty()
             if (foundUser.keycloakId != logggedInUserId && !isInSameProject) {
                 return@withCoroutineScope createNotFound("Unauthorized")

--- a/src/test/kotlin/fi/metatavu/lipsanen/functional/UserTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/lipsanen/functional/UserTestIT.kt
@@ -73,7 +73,7 @@ class UserTestIT: AbstractFunctionalTest() {
         val project1 = it.admin.project.create("project 1").id
         val project2 = it.admin.project.create("project 2").id
 
-        val user1 = it.admin.user.create("user1", UserRole.USER)
+        val user1 = it.admin.user.create("user1", UserRole.USER, projectId = project1)
         it.getUser("user1@example.com").project.listProjects()
 
         //Check that user with login history has some last login info

--- a/src/test/kotlin/fi/metatavu/lipsanen/functional/UserTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/lipsanen/functional/UserTestIT.kt
@@ -33,7 +33,7 @@ class UserTestIT: AbstractFunctionalTest() {
         val company = it.admin.company.create().id
         val jobPosition1 = it.admin.jobPosition.create(JobPosition("architect"))
 
-        it.admin.user.create("user1", UserRole.USER, project1, company, jobPosition1.id)
+        val user1 = it.admin.user.create("user1", UserRole.USER, project1, company, jobPosition1.id)
         it.admin.user.create("user2", UserRole.USER, project1)
         it.admin.user.create("user3", UserRole.USER, project2, company)
         it.admin.user.create("user4", UserRole.USER)
@@ -58,16 +58,39 @@ class UserTestIT: AbstractFunctionalTest() {
 
         val jobPositionUsers = it.admin.user.listUsers(jobPositionId = jobPosition1.id)
         assertEquals(1, jobPositionUsers.size)
+
+        val projectUsersListedByUser = it.getUser(user1.email).user.listUsers(projectId = project1)
+        assertEquals(2, projectUsersListedByUser.size)
+
+        val companyUsersListedByUser = it.getUser(user1.email).user.listUsers(companyId = company)
+        assertEquals(1, companyUsersListedByUser.size)
+
+        it.getUser(user1.email).user.assertListFailStatus(403, projectId = project2)
     }
 
     @Test
     fun testFindUser() = createTestBuilder().use {
+        val project1 = it.admin.project.create("project 1").id
+        val project2 = it.admin.project.create("project 2").id
+
         val user1 = it.admin.user.create("user1", UserRole.USER)
         it.getUser("user1@example.com").project.listProjects()
 
         //Check that user with login history has some last login info
         val foundUser2 = it.admin.user.findUser(user1.id!!)
         assertNotNull(foundUser2.lastLoggedIn)
+
+        // Test that user can find itself
+        val foundUser = it.getUser(user1.email).user.findUser(user1.id)
+        assertNotNull(foundUser)
+
+        val user2 = it.admin.user.create("user2", UserRole.USER, projectId = project1)
+        val user3 = it.admin.user.create("user3", UserRole.USER, projectId = project2)
+        // User 1 can find user 2 only since they share the project
+        val foundSameProjectUser = it.getUser(user1.email).user.findUser(user2.id!!)
+        assertNotNull(foundSameProjectUser)
+        // User 1 cannot find user 3 since they do not share the project
+        it.getUser(user1.email).user.assertFindFailStatus(404, user3.id!!)
     }
 
     @Test

--- a/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/UserTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/lipsanen/functional/impl/UserTestBuilderResource.kt
@@ -202,10 +202,13 @@ class UserTestBuilderResource (
      * @param expectedStatus expected status
      */
     fun assertListFailStatus(
-        expectedStatus: Int
+        expectedStatus: Int,
+        projectId: UUID? = null,
     ) {
         try {
-            api.listUsers()
+            api.listUsers(
+                projectId = projectId
+            )
             fail(String.format("Expected list to fail with status %d", expectedStatus))
         } catch (e: ClientException) {
             Assertions.assertEquals(expectedStatus.toLong(), e.statusCode.toLong())


### PR DESCRIPTION
https://github.com/Metatavu/lipsanen-project-management-api/issues/94
**Original task requirements:
Bugs:
"User" role cant use API findUser to get own data
"User" role can't list project users
User role is not automatically assigned to a newly created user**
Includes additional changes:

1. everyone except for User role can see all users (User role always has the project filter based on its projects)
2. User Management Admin is the one that can create/update/delete users
3. user roles are assigned based on the role property of the created user, therefore User Management Admin can even create Admins. If no role is provided, the new user is assigned to be User role.